### PR TITLE
Spawn second fruit after 170 pellets have been eaten

### DIFF
--- a/Pacman/inc/Systems/GameDirectorSystem.h
+++ b/Pacman/inc/Systems/GameDirectorSystem.h
@@ -27,12 +27,12 @@ public:
 			pokey->released = true;
 
 		if (player->pelletsEaten == 70 || player->pelletsEaten == 170){
-			if (fruitEntity == nullptr) {
-				fruitEntity.reset();
+			if (fruitEntityPtr) {
+				fruitEntityPtr.reset();
 			}
 			auto fruit = std::make_shared<FruitObject>(m_registry, m_gameInstance);
 			fruit->init(texturePath / "Entity" , m_fruitType);
-			fruitEntity = fruit;
+			fruitEntityPtr= fruit;
 		}
 	}
 
@@ -44,7 +44,7 @@ private:
 	bloom::Game*  m_gameInstance;
 	std::filesystem::path texturePath;
 
-	std::shared_ptr<bloom::GameObject> fruitEntity;
+	std::shared_ptr<bloom::GameObject> fruitEntityPtr;
 
 	FruitType m_fruitType;
 };

--- a/Pacman/inc/Systems/GameDirectorSystem.h
+++ b/Pacman/inc/Systems/GameDirectorSystem.h
@@ -26,11 +26,13 @@ public:
 		else if (player->pelletsEaten == pokey->dotLimit)
 			pokey->released = true;
 
-		if (player->pelletsEaten == 70)
-		{
+		if (player->pelletsEaten == 70 || player->pelletsEaten == 170){
+			if (fruitEntity == nullptr) {
+				fruitEntity.reset();
+			}
 			auto fruit = std::make_shared<FruitObject>(m_registry, m_gameInstance);
 			fruit->init(texturePath / "Entity" , m_fruitType);
-			m_entities.emplace_back(fruit);
+			fruitEntity = fruit;
 		}
 	}
 
@@ -42,7 +44,7 @@ private:
 	bloom::Game*  m_gameInstance;
 	std::filesystem::path texturePath;
 
-	std::vector<std::shared_ptr<bloom::GameObject>> m_entities;
+	std::shared_ptr<bloom::GameObject> fruitEntity;
 
 	FruitType m_fruitType;
 };


### PR DESCRIPTION
For some reason this is left out, this PR fixes that.

Also optimized `GameDirectorSystem` by removing the use of `std::vector` to store entity pointer