### PR TITLE
Refined scoring from eating ghosts

### DIFF
--- a/Pacman/inc/Components/PacmanComponent.h
+++ b/Pacman/inc/Components/PacmanComponent.h
@@ -10,6 +10,7 @@ struct Pacman {
 
 	int score = 0;
 	int pelletsEaten = 0;
+	int ghostsEaten = 0;					// Resets after a energizer (PowerPellet) is eaten
 	std::array<double, 2> multipliers;
 
 	bool dead = false;

--- a/Pacman/inc/Level.h
+++ b/Pacman/inc/Level.h
@@ -33,7 +33,7 @@ public:
 	void changeDir(Direction dir) {
 		m_registry.get<Pacman>(playerEntity->getEntityID()).nextDir = dir;
 	}
-	int getScore(entt::DefaultRegistry& m_registry) {
+	int getScore() {
 		return m_registry.get<Pacman>(playerEntity->getEntityID()).score;
 	}
 	void update(double dt) {

--- a/Pacman/inc/PlayerObject.h
+++ b/Pacman/inc/PlayerObject.h
@@ -62,10 +62,10 @@ public:
 		m_registry.accommodate<AnimationSet>(m_entity, animSet);
 		m_registry.accommodate<AnimationPtr>(m_entity, right);
 		if (!m_registry.has<Pacman>(m_entity))
-			m_registry.assign<Pacman>(m_entity) = Pacman{ Direction::null,Direction::null,0,0, speedMultipliers};
+			m_registry.assign<Pacman>(m_entity) = Pacman{ Direction::null,Direction::null,0,0,0, speedMultipliers};
 		else {
 			auto& pac = m_registry.get<Pacman>(m_entity);
-			pac = Pacman{ Direction::null,Direction::null,pac.score,0, speedMultipliers};
+			pac = Pacman{ Direction::null,Direction::null,pac.score,0,0, speedMultipliers};
 		}
 	}
 };

--- a/Pacman/inc/Systems/EdibleSystem.h
+++ b/Pacman/inc/Systems/EdibleSystem.h
@@ -36,6 +36,7 @@ public:
 				if (playerTile.x == pelletPos.x / TILESIZE && playerTile.y == pelletPos.y / TILESIZE) {
 					playerState.score += pellet.points;
 					++playerState.pelletsEaten;
+					playerState.ghostsEaten = 0;
 					playerState.timeAvailable -= (1000.0 / 60.0) * 3;
 					m_registry.destroy(entity);
 

--- a/Pacman/inc/Systems/GhostAI.h
+++ b/Pacman/inc/Systems/GhostAI.h
@@ -42,10 +42,7 @@ public:
 					}
 
 					if (ghost.currentMode == BehaviourModes::afraid && ghost.afraidTimer <= 0.0)
-					{
 						ghost.currentMode = ghost.previousMode;
-						playerState.ghostsEaten = 0;
-					}
 				}
 				AnimationSet& animSet = m_registry.get<AnimationSet>(entity);
 				while (potentialDistance > 0) {

--- a/Pacman/inc/Systems/GhostAI.h
+++ b/Pacman/inc/Systems/GhostAI.h
@@ -41,8 +41,11 @@ public:
 						}
 					}
 
-					if (ghost.currentMode == BehaviourModes::afraid && ghost.afraidTimer <= 0.0 )
+					if (ghost.currentMode == BehaviourModes::afraid && ghost.afraidTimer <= 0.0)
+					{
 						ghost.currentMode = ghost.previousMode;
+						playerState.ghostsEaten = 0;
+					}
 				}
 				AnimationSet& animSet = m_registry.get<AnimationSet>(entity);
 				while (potentialDistance > 0) {
@@ -104,7 +107,9 @@ public:
 				}
 				if (Tile ghostT{ (position.x + (GHOST_TEXTURESIZE / 2)) / TILESIZE,(position.y + (GHOST_TEXTURESIZE / 2)) / TILESIZE }, pac{ (playerPos.x + (PACMAN_TEXTURESIZE / 2)) / TILESIZE,(playerPos.y + (PACMAN_TEXTURESIZE / 2)) / TILESIZE }; pac == ghostT) {
 					if (ghost.currentMode == BehaviourModes::afraid) {
-						playerState.score += 6000;
+						playerState.score += 200 * pow(2, playerState.ghostsEaten);
+						++playerState.ghostsEaten;
+						playerState.score += (playerState.ghostsEaten >= 4) ? 12000 : 0;
 						ghost.currentMode = BehaviourModes::dead;
 					}
 					else if (ghost.currentMode != BehaviourModes::dead)

--- a/Pacman/main.cpp
+++ b/Pacman/main.cpp
@@ -59,17 +59,24 @@ void test_drawer(const std::filesystem::path& assetsPath)
 	sounds.add(audioDir / "pacman_beginning.wav");
 	sounds.add(audioDir / "pacman_intermission.wav");
 	sounds.add(audioDir / "pacman_death.wav");
+
+	std::cout << std::endl;
+	std::string consoleText{ "Level started!" };
+	std::cout << consoleText;
 	sounds[0]->play();
 	SDL_Delay(5000);
 
 	auto dt = 0.0;
 	int frameCount = 0;
-	std::cout << "Level is started!" << std::endl;
-	while (game->isRunning()) {
-		/* if (!frameCount)
-			std::cout << "Current score:  " << level.getScore(testRegistry) << std::endl; */
 
-		std::cout << "Delta time: " << dt << "ms" << std::endl;
+	while (game->isRunning()) {
+		for (char c : consoleText)
+			std::cout << "\b";
+		consoleText = "[FPS:" + std::to_string(static_cast<int>(1000.0 / dt + 0.5 > 99 ? 99 : 1000.0 / dt + 0.5)) + "] ";
+		consoleText += "Current score:  " + std::to_string(level.getScore());
+		std::cout << consoleText;
+
+		//std::cout << "Delta time: " << dt << "ms" << std::endl;
 
 		frameCount = (frameCount + 1) % 60;
 		game->handleEvents();
@@ -94,19 +101,22 @@ void test_drawer(const std::filesystem::path& assetsPath)
 		dt = game->timer.lap();
 
 		if (level.complete()) {
-			std::cout << "Level complete!" << std::endl;
+			consoleText += " -- Level complete!";
+			std::cout << " -- Level complete!";
 			sounds[1]->play();
 			game->delay(5500);
 			++levelNumber;
 			level.changeLevel(levelDir / "0.txt", levelNumber, tileDir);
 		}
 		else if (level.gameOver()) {
-			std::cout << "Game Over!" << std::endl;
+			consoleText += " -- Game over!";
+			std::cout << " -- Game Over!";
 			sounds[2]->play();
 			game->delay(1500);
 			break;
 		}
 	}
+	std::cout << std::endl;
 	game->destroy();
 }
 

--- a/Pacman/main.cpp
+++ b/Pacman/main.cpp
@@ -66,8 +66,8 @@ void test_drawer(const std::filesystem::path& assetsPath)
 	int frameCount = 0;
 	std::cout << "Level is started!" << std::endl;
 	while (game->isRunning()) {
-		/*if (!frameCount)
-			std::cout << "Current score:  " << level.getScore(testRegistry) << std::endl;*/
+		/* if (!frameCount)
+			std::cout << "Current score:  " << level.getScore(testRegistry) << std::endl; */
 
 		std::cout << "Delta time: " << dt << "ms" << std::endl;
 


### PR DESCRIPTION
This PR aims to make the score gain from eating ghosts more consistent with the original.
It follows this formula:
```
player.Score += 200 * 2 ^ ghostsEaten;
++ghostsEaten
```

`ghostsEaten` is resetted everytime a PowerPellet is eaten.

A bonus 12000pts is also given if Pacman is able to eat all ghosts within the same PowerPellet.
 